### PR TITLE
Add docs structure and MkDocs config

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,18 @@
+name: Build & Deploy
+on: [push]
+
+jobs:
+  site:
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install mkdocs-material
+      - run: mkdocs build --strict         # makes ./site/
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          cname: docs.hardfoc.dev          # writes CNAME file

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # hardfoc.github.io
-Holds org website
+
+This repository hosts the documentation site for the hardfoc project. It uses
+[MkDocs](https://www.mkdocs.org/) to build the static site and GitHub Pages to
+publish it.
+
+## Folder structure
+
+```
+.
+├── docs/                 # Markdown sources
+│   ├── getting-started/
+│   ├── api/
+│   ├── porting/
+│   └── hardware/
+├── mkdocs.yml            # MkDocs configuration
+├── index.md              # Home page
+└── .github/workflows/    # CI workflow
+```
+
+Pushes to `main` trigger the workflow in `.github/workflows/build-and-deploy.yml`
+which builds the site and updates the `gh-pages` branch.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+This folder contains the Markdown sources that are turned into the public website.
+
+```
+docs/
+  getting-started/
+  api/
+  porting/
+  hardware/
+```
+
+Each sub-folder has its own `README.md` which becomes a page on the site. The
+MkDocs configuration lives in the repository root as `mkdocs.yml`.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,3 @@
+# API Documentation
+
+Reference material for the project's API.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+Basic introduction and setup instructions will go here.

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -1,0 +1,3 @@
+# Hardware
+
+Notes and schematics for hardware-related topics.

--- a/docs/porting/README.md
+++ b/docs/porting/README.md
@@ -1,0 +1,3 @@
+# Porting Guide
+
+Instructions for porting the project to new hardware or platforms.

--- a/index.md
+++ b/index.md
@@ -1,0 +1,3 @@
+# Welcome
+
+This is the starting page for the hardfoc documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: hardfoc Documentation
+nav:
+  - Home: index.md
+  - Getting Started: docs/getting-started/README.md
+  - API: docs/api/README.md
+  - Porting: docs/porting/README.md
+  - Hardware: docs/hardware/README.md


### PR DESCRIPTION
## Summary
- create `docs/` with initial subfolders
- add placeholder README files and home page
- add `mkdocs.yml` configuration
- document repository layout in the root README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b57d673b883288a1a853ede3758c7