### PR TITLE
Fix nav paths in MkDocs config

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,18 @@
+name: Build & Deploy
+on: [push]
+
+jobs:
+  site:
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install mkdocs-material
+      - run: mkdocs build --strict         # makes ./site/
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          cname: docs.hardfoc.dev          # writes CNAME file

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # hardfoc.github.io
-Holds org website
+
+This repository hosts the documentation site for the hardfoc project. It uses
+[MkDocs](https://www.mkdocs.org/) to build the static site and GitHub Pages to
+publish it.
+
+## Folder structure
+
+```
+.
+├── docs/                 # Markdown sources
+│   ├── getting-started/
+│   ├── api/
+│   ├── porting/
+│   ├── hardware/
+│   └── index.md          # Home page
+├── mkdocs.yml            # MkDocs configuration
+└── .github/workflows/    # CI workflow
+```
+
+Pushes to `main` trigger the workflow in `.github/workflows/build-and-deploy.yml`
+which builds the site and updates the `gh-pages` branch.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+This folder contains the Markdown sources that are turned into the public website.
+
+```
+docs/
+  getting-started/
+  api/
+  porting/
+  hardware/
+```
+
+Each sub-folder has its own `README.md` which becomes a page on the site. The
+MkDocs configuration lives in the repository root as `mkdocs.yml`.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,3 @@
+# API Documentation
+
+Reference material for the project's API.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+Basic introduction and setup instructions will go here.

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -1,0 +1,3 @@
+# Hardware
+
+Notes and schematics for hardware-related topics.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Welcome
+
+This is the starting page for the hardfoc documentation.

--- a/docs/porting/README.md
+++ b/docs/porting/README.md
@@ -1,0 +1,3 @@
+# Porting Guide
+
+Instructions for porting the project to new hardware or platforms.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: hardfoc Documentation
+nav:
+  - Home: index.md
+  - About: README.md
+  - Getting Started: getting-started/README.md
+  - API: api/README.md
+  - Porting: porting/README.md
+  - Hardware: hardware/README.md


### PR DESCRIPTION
## Summary
- relocate the site homepage to `docs/index.md`
- update navigation entries to use relative paths
- adjust top-level README folder tree

## Testing
- ❌ `pip install mkdocs-material` *(fails: network disabled)*
- ❌ `mkdocs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b57d673b883288a1a853ede3758c7