### PR TITLE
Fix about page conflict and expand workflow docs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,18 @@
+name: Build & Deploy
+on: [push]
+
+jobs:
+  site:
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install mkdocs-material
+      - run: mkdocs build --strict         # makes ./site/
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          cname: docs.hardfoc.dev          # writes CNAME file

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # hardfoc.github.io
-Holds org website
+
+This repository hosts the documentation site for the hardfoc project. It uses
+[MkDocs](https://www.mkdocs.org/) to build the static site and GitHub Pages to
+publish it.
+
+## Folder structure
+
+```
+.
+├── docs/                 # Markdown sources
+│   ├── getting-started/
+│   ├── api/
+│   ├── porting/
+│   ├── hardware/
+│   ├── index.md          # Home page
+│   └── about.md          # About page
+├── mkdocs.yml            # MkDocs configuration
+└── .github/workflows/    # CI workflow
+```
+
+Pushes to `main` trigger the workflow in `.github/workflows/build-and-deploy.yml`
+which builds the site and updates the `gh-pages` branch.
+
+### How the workflow works
+
+1. **Checkout** – pulls the repo so the runner has the docs and config.
+2. **Setup Python** – installs a recent Python release for MkDocs.
+3. **Install MkDocs** – installs `mkdocs-material` to render the pages.
+4. **Build** – `mkdocs build --strict` generates the static site in `./site`.
+5. **Publish** – `peaceiris/actions-gh-pages` pushes that folder to the
+   `gh-pages` branch and writes the `CNAME` file so GitHub Pages serves
+   `https://docs.hardfoc.dev`.

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,14 @@
+# About This Documentation
+
+The `docs/` directory holds all Markdown files that become the published site.
+Each sub-folder provides a page on the site, for example:
+
+```
+docs/
+  getting-started/
+  api/
+  porting/
+  hardware/
+```
+
+`mkdocs.yml` at the repository root describes the navigation and theme.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,3 @@
+# API Documentation
+
+Reference material for the project's API.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+Basic introduction and setup instructions will go here.

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -1,0 +1,3 @@
+# Hardware
+
+Notes and schematics for hardware-related topics.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Welcome
+
+This is the starting page for the hardfoc documentation.

--- a/docs/porting/README.md
+++ b/docs/porting/README.md
@@ -1,0 +1,3 @@
+# Porting Guide
+
+Instructions for porting the project to new hardware or platforms.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: hardfoc Documentation
+nav:
+  - Home: index.md
+  - About: about.md
+  - Getting Started: getting-started/README.md
+  - API: api/README.md
+  - Porting: porting/README.md
+  - Hardware: hardware/README.md


### PR DESCRIPTION
## Summary
- rename `docs/README.md` to `docs/about.md`
- update MkDocs navigation to reference `about.md`
- describe workflow steps in the project README
