### PR TITLE
Enable Material theme for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository hosts the documentation site for the hardfoc project. It uses
 [MkDocs](https://www.mkdocs.org/) to build the static site and GitHub Pages to
 publish it.
 
+The site uses the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
+theme, which provides a sidebar and top navigation tabs configured in
+`mkdocs.yml`.
+
 ## Folder structure
 
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,3 +6,8 @@ nav:
   - API: api/README.md
   - Porting: porting/README.md
   - Hardware: hardware/README.md
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections


### PR DESCRIPTION
## Summary
- switch docs to mkdocs-material and enable navigation tabs/sections
- mention the material theme in the README